### PR TITLE
Refactored discordscorebot.py and added caching of ESPN scoreboards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 
 credentials_discord.py
 __pycache__/*
+*.pk1

--- a/discordscorebot.py
+++ b/discordscorebot.py
@@ -6,103 +6,105 @@ import discord
 from discord import Game
 from discord.ext.commands import Bot
 import espnscrape
+import pickle
 
 BOT_PREFIX = ("?", "!")
 
-teams = ["Toronto","Boston","Philadelphia","Cleveland","Indiana","Miami","Milwaukee Bucks","Washington","Detroit","Charlotte","New-York","Brooklyn","Chicago","Orlando","Atlanta","Houston","Golden State","Portland","Utah","New Orleans","San Antonio","Oklahoma City","Minnesota","Denver","LA","Los Angeles","Sacramento","Dallas","Memphis","Phoenix"]
-teams_short = ["TOR","BOS","PHI","CLE","IND","MIA","MIL","WSH","DET","CHA","NY","BKN","CHI","ORL","ATL","HOU","GS","POR","UTAH","NO","SA","OKC","MIN","DEN","LAC","LAL","SAC","DAL","MEM","PHX"]
+teams_full = {"Toronto","Boston","Philadelphia","Cleveland","Indiana","Miami","Milwaukee","Washington","Detroit","Charlotte","New-York","Brooklyn","Chicago","Orlando","Atlanta","Houston","Golden State","Portland","Utah","New Orleans","San Antonio","Oklahoma City","Minnesota","Denver","LA","Los Angeles","Sacramento","Dallas","Memphis","Phoenix"}
+teams_short = {"TOR","BOS","PHI","CLE","IND","MIA","MIL","WSH","DET","CHA","NY","BKN","CHI","ORL","ATL","HOU","GS","POR","UTAH","NO","SA","OKC","MIN","DEN","LAC","LAL","SAC","DAL","MEM","PHX"}
+teams = teams_full.union(teams_short)
+
 avaliable_roles = ["Game Night"]
 cbbid = "363172066431598595"
 
 client = Bot(command_prefix=BOT_PREFIX)
 
 ########################################
-#Score Bot Commands
-#cinciforthewin
-#Last Updated: 4/29/19
+# Score Bot Commands
+# cinciforthewin
+# Last Updated: 10/6/18 by Grubberbeb
 ########################################
 
 @client.command()
 async def allgames():
-	try:
-		gamestring = ''
-		for game in espnscrape.scrapeESPN(0):
-			gamestring = gamestring + game['team1'] + " " + str(game['score1']) + " vs. " + game['team2'] + " " + str(game['score2']) + " - " + game['time'] + "(TV: " + game['network'] + ")\n"
-		await client.say(gamestring)
-	except Exception as e:
-		print(str(e))
-		await client.say("Error Occured")
-		
+    try:
+        allGamesString = ''
+        for game in espnscrape.scrapeESPN(0):
+            allGamesString += buildGameString(game) + '\n'
+        await client.say(allGamesString)
+    except Exception as e:
+        print(str(e))
+        await client.say("Error Occured")
+
 @client.command()
 async def score(*,team:str):
-	try:
-		if team not in teams and team not in teams_short:
-			await client.say("Can't Find Team")
-			print("Can't Find Team")
-		else:
-			allgames = espnscrape.scrapeESPN(0)
-			if team in (game['team1'] for game in allgames) or team in (game['team2'] for game in allgames) or team in (game['team1abv'] for game in allgames) or team in (game['team2abv'] for game in allgames):
-				for game in allgames:
-					if team == game['team1'] or team == game['team2'] or team == game['team1abv'] or team == game['team2abv']:
-						gamestring = game['team2'] + " " + str(game['score2']) + " @ " + game['team1'] + " " + str(game['score1']) + " - " + game['time'] + " (TV: " + game['network'] + ")"
-						await client.say(gamestring)
-						print(gamestring)
-						break
-			else:
-				allgameteam = '**Past Games:**\n'
-				for n in range(-7,7):
-					allgames = espnscrape.scrapeESPN(n)
-					if team in (game['team1'] for game in allgames) or team in (game['team2'] for game in allgames) or team in (game['team1abv'] for game in allgames) or team in (game['team2abv'] for game in allgames):
-						for game in allgames:
-							if team == game['team1'] or team == game['team2'] or team == game['team1abv'] or team == game['team2abv']:
-								gamestring = game['team2'] + " " + str(game['score2']) + " @ " + game['team1'] + " " + str(game['score1']) + " - " + game['time'] + " (TV: " + game['network'] + ")"
-								allgameteam = allgameteam + gamestring + "\n"
-								print(gamestring)
-					if n == 0:
-						allgameteam = allgameteam + "**Future Games:**\n"
-						
-				await client.say("There are currently no games today.\n" + allgameteam)
-				#print("No Games")
-	except Exception as e:
-		print(str(e))
-		await client.say("Error Occured")
-		
+    try:
+        if team in teams:
+            await client.say(buildScoreString(team))
+        else:
+            await client.say("Can't Find Team")
+            print("Can't Find Team")
+    except Exception as e:
+        print(str(e))
+        await client.say("Error Occured")
+
 @client.command()
 async def schedule(*,team:str):
-	try:
-		if team not in teams and team not in teams_short:
-			await client.say("Can't Find Team")
-			print("Can't Find Team")
-		else:
-			allgames = espnscrape.scrapeESPN(0)
-			allgameteam = '**Past Games:**\n'
-			for n in range(-7,7):
-				gameday = False
-				allgames = espnscrape.scrapeESPN(n)
-				if team in (game['team1'] for game in allgames) or team in (game['team2'] for game in allgames) or team in (game['team1abv'] for game in allgames) or team in (game['team2abv'] for game in allgames):
-					for game in allgames:
-						if team == game['team1'] or team == game['team2'] or team == game['team1abv'] or team == game['team2abv']:
-							gamestring = game['team2'] + " " + str(game['score2']) + " @ " + game['team1'] + " " + str(game['score1']) + " - " + game['time'] + " (TV: " + game['network'] + ")"
-							gameday = True
-							allgameteam = allgameteam + gamestring + "\n"
-							print(gamestring)
-				if n == -1:
-					allgameteam = allgameteam + "**Today's Game:**\n"
-				elif n == 0:
-					# print("Enter 0 if")
-					#print(gameday)
-					if not gameday:
-						# print("entered if not statement")
-						allgameteam = allgameteam.replace("**Today's Game:**\n","")
-						
-					allgameteam = allgameteam + "**Future Game:**\n"
-					
-			await client.say("Basketball Schedule for "+team+"\n"+allgameteam)
-			#print("No Games")
-	except Exception as e:
-		print(str(e))
-		await client.say("Error Occured")
-		
+    try:
+        if team in teams:
+            scheduleString = buildScheduleString(team)
+            await client.say('Basketball Schedule for ' + team + ':\n' + scheduleString)
+        else:
+            await client.say("Can't Find Team")
+            print("Can't Find Team")
+    except Exception as e:
+        print(str(e))
+        await client.say("Error Occured")
+
+def gameTeams(game):
+    return {game['team1'], game['team2'], game['team1abv'], game['team2abv']}
+
+def buildGameString(game):
+    return game['team2'] + " " + str(game['score2']) + " @ " + game['team1'] + " " + str(game['score1']) + " - " + game['time'] + " (TV: " + game['network'] + ")"
+
+def buildScoreString(team):
+    allgames = espnscrape.scrapeESPN(0)
+    for game in allgames:
+        if team in gameTeams(game):
+            gamestring = buildGameString(game)
+            print(gamestring)
+            return gamestring
+
+    scheduleString = buildScheduleString(team, includeToday=False)
+    return "There are currently no games scheduled for " + team + " today.\n" + scheduleString
+
+def buildScheduleString(team, includeToday=True):
+    scheduleString = '**Past Games:**\n'
+    for n in range(-7, 8):
+        if n == 0:
+            if includeToday:
+                scheduleString += "**Today's Game:**\n"
+            else:
+                continue
+        if n == 1:
+            scheduleString += '**Future Games:**\n'
+
+        allGamesOnDay = getAllGamesOnDay(n)
+        for game in allGamesOnDay:
+            if team in gameTeams(game):
+                gamestring = buildGameString(game)
+                scheduleString += gamestring + '\n'
+                print(gamestring)
+                break
+    return scheduleString
+
+def getAllGamesOnDay(n):
+    if n == 0:
+        return espnscrape.scrapeESPN(0)
+    else:
+        with open('discordscorebot/' + str(n) + '.pk1', 'rb') as dayCache:
+            return pickle.load(dayCache)
+
 @client.event
 async def on_ready():
     await client.change_presence(game=Game(name="Basketball"))
@@ -117,51 +119,51 @@ async def list_servers():
         await asyncio.sleep(600)
 
 async def liveticker():
-	await client.wait_until_ready()
-	channel = discord.Object(id=CHANNEL_ID)
-	while not client.is_closed:
-		try:
-			await client.send_message(channel,espnscrape.ScoreTickBuilder())
-			await asyncio.sleep(30)
-		except KeyboardInterrupt:
-			exit()
-		except Exception as e:
-			await asyncio.sleep(30)
-			continue
+    await client.wait_until_ready()
+    channel = discord.Object(id=CHANNEL_ID)
+    while not client.is_closed:
+        try:
+            await client.send_message(channel,espnscrape.ScoreTickBuilder())
+            await asyncio.sleep(30)
+        except KeyboardInterrupt:
+            exit()
+        except Exception as e:
+            await asyncio.sleep(30)
+            continue
 
-########################################			
+########################################
 # Assign Role
 # By cinciforthewin
-# Last Updated: 4/29/19
+# Last Updated: 4/29/18
 ########################################
 
 @client.command(pass_context=True)
 async def addrole(ctx,*,req_role:str):
-	if req_role not in avaliable_roles:
-		sendstr = "The Role requested is not available to add or remove.  These roles are currently available:\n"
-		for a_role in avaliable_roles:
-			sendstr = sendstr + "* " + a_role + "\n"
-		await client.say(sendstr)
-	else:
-		for server in client.servers:
-			if server.id == cbbid:
-				role = discord.utils.get(server.roles,name=req_role)
-				await client.add_roles(ctx.message.author,role)
-				await client.say(ctx.message.author.name + " added to the " + req_role + " role.")
-				
+    if req_role not in avaliable_roles:
+        sendstr = "The Role requested is not available to add or remove.  These roles are currently available:\n"
+        for a_role in avaliable_roles:
+            sendstr = sendstr + "* " + a_role + "\n"
+        await client.say(sendstr)
+    else:
+        for server in client.servers:
+            if server.id == cbbid:
+                role = discord.utils.get(server.roles,name=req_role)
+                await client.add_roles(ctx.message.author,role)
+                await client.say(ctx.message.author.name + " added to the " + req_role + " role.")
+
 @client.command(pass_context=True)
 async def removerole(ctx,*,req_role:str):
-	if req_role not in avaliable_roles:
-		sendstr = "The Role requested is not available to add or remove.  These roles are currently available:\n"
-		for a_role in avaliable_roles:
-			sendstr = sendstr + "* " + a_role + "\n"
-		await client.say(sendstr)
-	else:
-		for server in client.servers:
-			if server.id == cbbid:
-				role = discord.utils.get(server.roles,name=req_role)
-				await client.remove_roles(ctx.message.author,role)
-				await client.say(ctx.message.author.name + " removed from the " + req_role + " role.")
+    if req_role not in avaliable_roles:
+        sendstr = "The Role requested is not available to add or remove.  These roles are currently available:\n"
+        for a_role in avaliable_roles:
+            sendstr = sendstr + "* " + a_role + "\n"
+        await client.say(sendstr)
+    else:
+        for server in client.servers:
+            if server.id == cbbid:
+                role = discord.utils.get(server.roles,name=req_role)
+                await client.remove_roles(ctx.message.author,role)
+                await client.say(ctx.message.author.name + " removed from the " + req_role + " role.")
 
 client.loop.create_task(list_servers())
 client.loop.create_task(liveticker())

--- a/espnscrape.py
+++ b/espnscrape.py
@@ -3,8 +3,9 @@ import json
 #import time
 from fake_useragent import UserAgent
 import html
-from datetime import datetime  
+from datetime import datetime
 from datetime import timedelta
+import pickle
 
 GAME_STATUS_PRE = 0
 GAME_STATUS_IN = 1
@@ -18,159 +19,171 @@ POS_PTWO = 6
 POS_FINAL = 7
 
 def _returntime(delta):
-	#Current Time will always be adjusted backwards 4 hours (4 am eastern will change over the day, allowing games to finish.)
-	_currenttime = datetime.now()+timedelta(days=delta)+timedelta(hours=-4)
-	
-	return _addfrontzero(_currenttime.year)+_addfrontzero(_currenttime.month)+_addfrontzero(_currenttime.day)
-		
+    #Current Time will always be adjusted backwards 4 hours (4 am eastern will change over the day, allowing games to finish.)
+    _currenttime = datetime.now()+timedelta(days=delta)+timedelta(hours=-4)
+
+    return _addfrontzero(_currenttime.year)+_addfrontzero(_currenttime.month)+_addfrontzero(_currenttime.day)
+
 def _addfrontzero(value):
-	if value < 10:
-		return "0" + str(value)
-	else:
-		return str(value)
+    if value < 10:
+        return "0" + str(value)
+    else:
+        return str(value)
 
 def scrapeESPN(delta=0):
 
-	#MODE_ACTIVE = 0
-	#MODE_INACTIVE = 1
-		
-	req = Request("http://www.espn.com/nba/scoreboard/_/date/" + _returntime(delta))
-	req.headers["User-Agent"] = UserAgent(verify_ssl=False).chrome
+    #MODE_ACTIVE = 0
+    #MODE_INACTIVE = 1
 
-	# Load data
-	scoreData = urlopen(req).read().decode("utf-8")
-	scoreData = scoreData[scoreData.find('window.espn.scoreboardData 	= ')+len('window.espn.scoreboardData 	= '):]
-	scoreData = json.loads(scoreData[:scoreData.find('};')+1])
+    req = Request("http://www.espn.com/nba/scoreboard/_/date/" + _returntime(delta))
+    req.headers["User-Agent"] = UserAgent(verify_ssl=False).chrome
 
-	games = []
-	for event in scoreData['events']:
-		game = dict()
+    # Load data
+    scoreData = urlopen(req).read().decode("utf-8")
+    scoreData = scoreData[scoreData.find('window.espn.scoreboardData 	= ')+len('window.espn.scoreboardData 	= '):]
+    scoreData = json.loads(scoreData[:scoreData.find('};')+1])
 
-		game["date"] = event['date']
-		status = event['status']['type']['state']
-		if status == "pre":
-			game['status'] = GAME_STATUS_PRE
-		elif status == "in":
-			game['status'] = GAME_STATUS_IN
-		else:
-			game['status'] = GAME_STATUS_POST
-		team1 = html.unescape(event['competitions'][0]['competitors'][0]['team']['location'])
-		tid1 = event['competitions'][0]['competitors'][0]['id']
-		score1 = int(event['competitions'][0]['competitors'][0]['score'])
-		team1abv = event['competitions'][0]['competitors'][0]['team']['abbreviation']
-		team2 = html.unescape(event['competitions'][0]['competitors'][1]['team']['location'])
-		tid2 = event['competitions'][0]['competitors'][1]['id']
-		score2 = int(event['competitions'][0]['competitors'][1]['score'])
-		team2abv = event['competitions'][0]['competitors'][1]['team']['abbreviation']
-        
-		# Hawaii workaround (Built for College, not NBA)
-		if team1 == "Hawai'i":
-			team1 = "Hawaii"
-		if team2 == "Hawai'i":
-			team2 = "Hawaii"
+    games = []
+    for event in scoreData['events']:
+        game = dict()
 
-		homestatus = event['competitions'][0]['competitors'][0]['homeAway']
+        game["date"] = event['date']
+        status = event['status']['type']['state']
+        if status == "pre":
+            game['status'] = GAME_STATUS_PRE
+        elif status == "in":
+            game['status'] = GAME_STATUS_IN
+        else:
+            game['status'] = GAME_STATUS_POST
+        team1 = html.unescape(event['competitions'][0]['competitors'][0]['team']['location'])
+        tid1 = event['competitions'][0]['competitors'][0]['id']
+        score1 = int(event['competitions'][0]['competitors'][0]['score'])
+        try: # This try/catch, like the one below, allows this to work when an NBA team plays an international team
+            team1abv = event['competitions'][0]['competitors'][0]['team']['abbreviation']
+        except KeyError:
+            team1abv = team1
+        team2 = html.unescape(event['competitions'][0]['competitors'][1]['team']['location'])
+        tid2 = event['competitions'][0]['competitors'][1]['id']
+        score2 = int(event['competitions'][0]['competitors'][1]['score'])
+        try:
+            team2abv = event['competitions'][0]['competitors'][1]['team']['abbreviation']
+        except KeyError:
+            team2abv = team2
 
-		if homestatus == 'home':
-			game['hometeam'], game['homeid'], game['homeabv'], game['homescore'], game['awayteam'], game['awayid'], game['awayabv'], game['awayscore'] =\
-				team1, tid1, team1abv, score1, team2, tid2, team2abv, score2
-		else:
-			game['hometeam'], game['homeid'], game['homeabv'], game['homescore'], game['awayteam'], game['awayid'], game['awayabv'], game['awayscore'] = \
-				team2, tid2, team2abv, score2, team1, tid1, team1abv, score1
+        # Hawaii workaround (Built for College, not NBA)
+        if team1 == "Hawai'i":
+            team1 = "Hawaii"
+        if team2 == "Hawai'i":
+            team2 = "Hawaii"
 
-		game['time'] = event['status']['type']['shortDetail']
+        homestatus = event['competitions'][0]['competitors'][0]['homeAway']
+
+        if homestatus == 'home':
+            game['hometeam'], game['homeid'], game['homeabv'], game['homescore'], game['awayteam'], game['awayid'], game['awayabv'], game['awayscore'] =\
+                team1, tid1, team1abv, score1, team2, tid2, team2abv, score2
+        else:
+            game['hometeam'], game['homeid'], game['homeabv'], game['homescore'], game['awayteam'], game['awayid'], game['awayabv'], game['awayscore'] = \
+                team2, tid2, team2abv, score2, team1, tid1, team1abv, score1
+
+        game['time'] = event['status']['type']['shortDetail']
 
 #		gamestring = team1 + " " + str(score1) + " vs. " + team2 + " " + str(score2) + " - " + game['time']
-		try:
-			game['network'] = event['competitions'][0]['broadcasts'][0]['names'][0]
+        try:
+            game['network'] = event['competitions'][0]['broadcasts'][0]['names'][0]
 #			gamestring += " (TV: " + game['network'] + ")"
-		except:
-			game['network'] = "N/A"
-			pass
-            
-		#print(team1,tid1,team1abv,score1,team2,tid2,team2abv,score2,game['time'],game['date'],game['network'])
-		indgame = {'team1':team1,'tid1':tid1,'team1abv':team1abv,'score1':score1,'team2':team2,'tid2':tid2,'team2abv':team2abv,'score2':score2,'time':game['time'],'date':game['date'],'network':game['network'],'status':game['status']}
-		games.append(indgame)
+        except:
+            game['network'] = "N/A"
+            pass
+
+        #print(team1,tid1,team1abv,score1,team2,tid2,team2abv,score2,game['time'],game['date'],game['network'])
+        indgame = {'team1':team1,'tid1':tid1,'team1abv':team1abv,'score1':score1,'team2':team2,'tid2':tid2,'team2abv':team2abv,'score2':score2,'time':game['time'],'date':game['date'],'network':game['network'],'status':game['status']}
+        games.append(indgame)
 #		print(gamestring)
-	return games
+
+    # Cache results to avoid further requests
+    if delta != 0:
+        with open('discordscorebot/' + str(delta) + '.pk1', 'wb') as dayCache:
+            pickle.dump(games, dayCache, pickle.HIGHEST_PROTOCOL)
+
+    return games
 
 def returnallgames(time=0):
-	gamestrings = ''
-	for game in scrapeESPN(time):
-		gamestrings = gamestrings + game['team1'] + " " + str(game['score1']) + " vs. " + game['team2'] + " " + str(game['score2']) + " - " + game['time'] + "(TV: " + game['network'] + ")"
-	return gamestrings
+    gamestrings = ''
+    for game in scrapeESPN(time):
+        gamestrings = gamestrings + game['team1'] + " " + str(game['score1']) + " vs. " + game['team2'] + " " + str(game['score2']) + " - " + game['time'] + "(TV: " + game['network'] + ")"
+    return gamestrings
 
 def readlog():
-	with open('discordscorebot/gamelog.txt','r') as f:
-		lines = f.readlines()
-		
-	allgames = []
-	for line in lines:
-		game = line.replace('\n','').split(',')
-		allgames.append(game)
-	
-	return allgames
-	
+    with open('discordscorebot/gamelog.txt','r') as f:
+        lines = f.readlines()
+
+    allgames = []
+    for line in lines:
+        game = line.replace('\n','').split(',')
+        allgames.append(game)
+
+    return allgames
+
 def writelog(allgames):
-	with open('discordscorebot/gamelog.txt','w') as f:
-		for game in allgames:
-			string = ''
-			for item in game[:-1]:
-				string = string + item + ','
-			string = string+game[-1]+'\n'
-			f.write(string)
-			
+    with open('discordscorebot/gamelog.txt','w') as f:
+        for game in allgames:
+            string = ''
+            for item in game[:-1]:
+                string = string + item + ','
+            string = string+game[-1]+'\n'
+            f.write(string)
+
 def ScoreTickBuilder():
-	games = scrapeESPN()
-	livetickerstr = ''
-	allgamelog = readlog() 
-	for game in games:
-		if game['status'] == GAME_STATUS_PRE:
-			continue
-		elif game['status'] == GAME_STATUS_POST:
-			for log in allgamelog:
-				if log[0] == game['tid1'] or log[0] == game['tid2']:
-					if log[7] == '0':
-						log[7] = '1'
-						livetickerstr = livetickerstr + game['team2'] + " " + str(game['score2']) + " @ " + game['team1'] + " " + str(game['score1']) + " - " + game['time'] + " (TV: " + game['network'] + ")\n"
-						break
-					else:
-						break
-		else:
-			livetickerstrret, allgamelog = gameinprocess(game,allgamelog)
-			livetickerstr = livetickerstr + livetickerstrret + '\n'
-			
-	writelog(allgamelog)
-	return livetickerstr
+    games = scrapeESPN()
+    livetickerstr = ''
+    allgamelog = readlog()
+    for game in games:
+        if game['status'] == GAME_STATUS_PRE:
+            continue
+        elif game['status'] == GAME_STATUS_POST:
+            for log in allgamelog:
+                if log[0] == game['tid1'] or log[0] == game['tid2']:
+                    if log[7] == '0':
+                        log[7] = '1'
+                        livetickerstr = livetickerstr + game['team2'] + " " + str(game['score2']) + " @ " + game['team1'] + " " + str(game['score1']) + " - " + game['time'] + " (TV: " + game['network'] + ")\n"
+                        break
+                    else:
+                        break
+        else:
+            livetickerstrret, allgamelog = gameinprocess(game,allgamelog)
+            livetickerstr = livetickerstr + livetickerstrret + '\n'
+
+    writelog(allgamelog)
+    return livetickerstr
 
 def gameinprocess(game,allgamelog):
-	if game['time'] == 'Halftime':
-		if not ifposted(allgamelog,game['tid1'],POS_HALF):
-			return gamestring(game), updateprelog(allgamelog,game['tid1'],POS_HALF)
-	elif game['time'] == 'End of 1st':
-		if not ifposted(allgamelog,game['tid1'],POS_TEN):
-			return gamestring(game), updateprelog(allgamelog,game['tid1'],POS_TEN)
-	elif game['time'] == 'End of 3rd':
-		if not ifposted(allgamelog,game['tid1'],POS_PTEN):
-			return gamestring(game), updateprelog(allgamelog,game['tid1'],POS_PTEN)
+    if game['time'] == 'Halftime':
+        if not ifposted(allgamelog,game['tid1'],POS_HALF):
+            return gamestring(game), updateprelog(allgamelog,game['tid1'],POS_HALF)
+    elif game['time'] == 'End of 1st':
+        if not ifposted(allgamelog,game['tid1'],POS_TEN):
+            return gamestring(game), updateprelog(allgamelog,game['tid1'],POS_TEN)
+    elif game['time'] == 'End of 3rd':
+        if not ifposted(allgamelog,game['tid1'],POS_PTEN):
+            return gamestring(game), updateprelog(allgamelog,game['tid1'],POS_PTEN)
 
-	#Reached if it makes it through the if statements.
-	string = ''
-	return string,allgamelog
-			
+    #Reached if it makes it through the if statements.
+    string = ''
+    return string,allgamelog
+
 def gamestring(game):
-	return game['team2'] + " " + str(game['score2']) + " @ " + game['team1'] + " " + str(game['score1']) + " - " + game['time'] + " (TV: " + game['network'] + ")"
-			
+    return game['team2'] + " " + str(game['score2']) + " @ " + game['team1'] + " " + str(game['score1']) + " - " + game['time'] + " (TV: " + game['network'] + ")"
+
 def updateprelog(allgamelog,gameteam,pos):
-	for log in allgamelog:
-		if log[0] == gameteam or log[1] == gameteam:
-			log[pos] = '1'
-	return allgamelog
+    for log in allgamelog:
+        if log[0] == gameteam or log[1] == gameteam:
+            log[pos] = '1'
+    return allgamelog
 
 def ifposted(allgamelog,gameteam,pos):
-	for log in allgamelog:
-		if log[0] == gameteam or log[1] == gameteam:
-			if log[pos] == '0':
-				return False
-			else:
-				return True
+    for log in allgamelog:
+        if log[0] == gameteam or log[1] == gameteam:
+            if log[pos] == '0':
+                return False
+            else:
+                return True

--- a/nightlyreset.py
+++ b/nightlyreset.py
@@ -1,9 +1,16 @@
 from espnscrape import scrapeESPN
 
 def createnewlog():
-	games = scrapeESPN(0)
-	with open('discordscorebot/gamelog.txt','w') as f:
-		for game in games:
-			f.write(game['tid1'] + "," + game['tid2'] + "," + '0,0,0,0,0,0\n') #tid1,tid2,10-1h,half,10-2h,5-2h,2-2h,final
-			
+    games = scrapeESPN(0)
+    with open('discordscorebot/gamelog.txt','w') as f:
+        for game in games:
+            f.write(game['tid1'] + "," + game['tid2'] + "," + '0,0,0,0,0,0\n') #tid1,tid2,10-1h,half,10-2h,5-2h,2-2h,final
+
+def cacheGames():
+    for n in range(-7, 8):
+        if n == 0: # Don't use a cache for today since the results will most likely be changing
+            continue
+        scrapeESPN(n)
+
 createnewlog()
+cacheGames()

--- a/test.py
+++ b/test.py
@@ -1,0 +1,5 @@
+from discordscorebot import buildScoreString, buildScheduleString
+
+print(buildScoreString("Boston"))
+print('\n\n')
+print(buildScheduleString("CHI"))


### PR DESCRIPTION
There was a looooot of looping going on in discordscorebot.py which I was able to refactor away, so that should be faster now. But more importantly, I added a caching feature using Python's builtin pickle module. So now when you run nightlyreset, it will pull the ESPN scoreboards from a week into the past and future and store them as .pk1 files in the discordscorebot folder. So when somebody uses the schedule command, the bot reads from these cache files rather than creating new ESPN requests. Similarly if somebody tries to use the score command and the provided team has no games today, the same caching is leveraged to show the team's schedule. There's no caching for the current day since the scoreboard is most likely going to change. This should massively speed things up and make it usable.

When nightlyreset is run, it will overwrite any existing cache files. So there's no need to do anything differently, just running nightlyreset at 4AM should be good still.

Also, there's a call to UserAgent() on line 39 of espnscrape.py, so you might have to change this like we did for the settingsbot.

Refactoring also allowed me to write a test.py script. If you run nightlyreset once before running the test at all, then it should be fast from the start. Otherwise the first test run will be slow since it's generating the cache files, but after that it should always be fast even if you change the tests. There's some double printing that happens when you run it, but that's just stuff printing to stdout and isn't reflected in the calls to client.say(). Hopefully being able to mess around in that test.py will be enough to be confident that this will work lol. Let me know if there's anything you want me to clarify!